### PR TITLE
[FIX] WARNING! node-cache legacy callback support will drop in v6.x

### DIFF
--- a/client.js
+++ b/client.js
@@ -57,26 +57,20 @@ module.exports = function ldapClient(context) {
         });
     }
 
-    client.executeQuery = function(ldapQuery, objectFactory, modelMapper, isResultUniq, next) {  
-        context.memoryCache.get(ldapQuery+isResultUniq, function (err, data) {
-            if (!err) {
-                if (data == undefined) {
-                    cacheQuery(ldapQuery, objectFactory, modelMapper, isResultUniq, function(err, data) {
-                        context.memoryCache.set(ldapQuery+isResultUniq, data, function (err, success) {
-                            if (!err && success) {
-                                next(null, data);
-                            } else {
-                                next({ Error: "aararrggghhh!" }, null);
-                            }
-                        });
-                    });
-                } else {
+    client.executeQuery = function(ldapQuery, objectFactory, modelMapper, isResultUniq, next) {
+        let data = context.memoryCache.get(ldapQuery+isResultUniq)
+        if (data == undefined) {
+            cacheQuery(ldapQuery, objectFactory, modelMapper, isResultUniq, function(err, data) {
+                let success = context.memoryCache.set(ldapQuery+isResultUniq, data);
+                if (success) {
                     next(null, data);
+                } else {
+                    next({ Error: "Error setting cache" }, null);
                 }
-            } else {
-                next({ Error: "aararrggghhh!" }, null);
-            }
-        });
+            });
+        } else {
+            next(null, data);
+        }
     };
 
     return client;

--- a/context.js
+++ b/context.js
@@ -1,6 +1,6 @@
 ﻿'use strict';
+let NodeCache = require("node-cache");
 module.exports = function ldapContext(options) {
-    let NodeCache = require("node-cache");
     let context = {};
     context.client = require('./client')(context);
     context.options = require('./options')();
@@ -8,10 +8,12 @@ module.exports = function ldapContext(options) {
     context.units = require('./repositories/units')(context);
     context.viewModelsMappers = require('./viewModels/mappers')();
 
-    if (options == undefined || options.memoryCache == undefined ) {
-        context.memoryCache = new NodeCache({ stdTTL: 14400, enableLegacyCallbacks: true }); // 4 hour of cache
-    } else {
-        context.memoryCache = new NodeCache(options.memoryCache);
+    if (context.memoryCache == undefined) {
+        if (options == undefined || options.memoryCache == undefined ) {
+            context.memoryCache = new NodeCache({ stdTTL: 14400 }); // 4 hour of cache
+        } else {
+            context.memoryCache = new NodeCache(options.memoryCache);
+        }
     }
     return context;
 };

--- a/test/init.js
+++ b/test/init.js
@@ -1,11 +1,13 @@
 before(function() {
-  //console.log('before test in every file');
+  // console.log('before test in every file');
+  var fullLdapContext = require('../context')();
+  fullLdapContext.options.modelsMapper = fullLdapContext.viewModelsMappers.full;
+  // create a context for all the test, allowing to create/remove cache
+  this.fullLdapContext = fullLdapContext;
 });
-
 
 beforeEach(function() {
   // Be sure to clear the cache before the tests...
   // console.log('clearing cache...');
-  var fullLdapContext = require('../context')();
-  fullLdapContext.memoryCache.flushAll();
+  this.fullLdapContext.memoryCache.flushAll();
 });

--- a/test/unitTest.js
+++ b/test/unitTest.js
@@ -1,32 +1,30 @@
 var assert = require('assert');
-var fullLdapContext = require('../context')();
-fullLdapContext.options.modelsMapper = fullLdapContext.viewModelsMappers.full;
 
 describe('Units::get', function () {
 
     it('get unit by id', function(done) {
-        fullLdapContext.units.getUnitById('1906', function (err, data) {
+        this.fullLdapContext.units.getUnitById('1906', function (err, data) {
             assert.ok(data.name === "SI - Full-Stack Development", "Unit name");
             done();
         });
     });
-  
+
     it('get unit by accounting number', function (done) {
-        fullLdapContext.units.getUnitByAccountingNumber('1906', function (err, data) {
+        this.fullLdapContext.units.getUnitByAccountingNumber('1906', function (err, data) {
             assert.ok(data.name === "SI - Full-Stack Development", "Unit name");
             done();
         });
     });
- 
+
     it('get unit by unique identifier', function (done) {
-        fullLdapContext.units.getUnitByUniqueIdentifier(13030, function (err, data) {
+        this.fullLdapContext.units.getUnitByUniqueIdentifier(13030, function (err, data) {
             assert.ok(data.name === "SI - Full-Stack Development", "Unit name");
             done();
         });
     });
-  
+
     it('get unit by name', function (done) {
-        fullLdapContext.units.getUnitByName("SI - Full-Stack Development", function (err, data) {
+        this.fullLdapContext.units.getUnitByName("SI - Full-Stack Development", function (err, data) {
             assert.ok(data.uniqueIdentifier === '13030', "Unit unique identifier");
             done();
         });
@@ -37,7 +35,7 @@ describe('Units::get', function () {
 describe('Units::search', function () {
 
     it('search unit by name', function (done) {
-        fullLdapContext.units.searchUnitByName("Full-Stack Development", function (err, data) {
+        this.fullLdapContext.units.searchUnitByName("Full-Stack Development", function (err, data) {
             assert.ok(data[0].uniqueIdentifier === '13030', "Unit unique identifier");
             done();
         });

--- a/test/userTest.js
+++ b/test/userTest.js
@@ -1,46 +1,46 @@
 ﻿var assert = require('assert');
-var fullLdapContext = require('../context')();
-fullLdapContext.options.modelsMapper = fullLdapContext.viewModelsMappers.full;
+// var fullLdapContext = require('../context')();
+// fullLdapContext.options.modelsMapper = fullLdapContext.viewModelsMappers.full;
 
 describe('User::get', function () {
 
     it('getUserBySciper should get Kermit La Grenouille', function (done) {
-        fullLdapContext.users.getUserBySciper(133134, function (err, data) {
+        this.fullLdapContext.users.getUserBySciper(133134, function (err, data) {
             assert.equal(data.displayName, "Kermit La Grenouille");
             done();
         });
     });
 
     it('getUserBySciper should handle users with two email', function(done) {
-        fullLdapContext.users.getUserBySciper(162314, function (err, data) {
+        this.fullLdapContext.users.getUserBySciper(162314, function (err, data) {
             assert.ok(data.emails.length === 2, "User have 2 email");
             done();
         });
     });
 
     it('getUserBySciper should return correct email length', function (done) {
-        fullLdapContext.users.getUserBySciper(169419, function (err, data) {
+        this.fullLdapContext.users.getUserBySciper(169419, function (err, data) {
             assert.ok(data.emails[0].length === 23, "Email adresse has the correct length");
             done();
         });
     });
 
     it('getUserByName should find Kermit La Grenouille', function (done) {
-        fullLdapContext.users.getUserByName('Kermit La Grenouille', function (err, data) {
+        this.fullLdapContext.users.getUserByName('Kermit La Grenouille', function (err, data) {
             assert.equal(data.displayName, 'Kermit La Grenouille');
             done();
         });
     });
 
     it('getUserByPhone should find 169419', function (done) {
-        fullLdapContext.users.getUserByPhone('+41 21 6935455', function (err, data) {
+        this.fullLdapContext.users.getUserByPhone('+41 21 6935455', function (err, data) {
             assert.equal(data.sciper, '169419');
             done();
         });
     });
 
     it('getUserByPhone should find 169419', function (done) {
-        fullLdapContext.users.getUserByPhone('35455', function (err, data) {
+        this.fullLdapContext.users.getUserByPhone('35455', function (err, data) {
             assert.equal(data.sciper, '169419');
             done();
         });
@@ -48,7 +48,7 @@ describe('User::get', function () {
 
     // Watch out: user with guest account on their EPFL email can appear first.
     it('getUserByMail should find 188475', function (done) {
-        fullLdapContext.users.getUserByMail('gregory.charmier@epfl.ch', function (err, data) {
+        this.fullLdapContext.users.getUserByMail('gregory.charmier@epfl.ch', function (err, data) {
             assert.equal(data.sciper, '188475');
             done();
         });
@@ -59,21 +59,21 @@ describe('User::get', function () {
 describe('User::search', function () {
 
     it('searchUserByName should search Kermit La Grenouille', function (done) {
-        fullLdapContext.users.searchUserByName('Kermit', function (err, data) {
+        this.fullLdapContext.users.searchUserByName('Kermit', function (err, data) {
             assert.equal(data[0].displayName, 'Kermit La Grenouille');
             done();
         });
     });
 
     it('searchUserByPhone should return 169419', function (done) {
-        fullLdapContext.users.searchUserByPhone('35455', function (err, data) {
+        this.fullLdapContext.users.searchUserByPhone('35455', function (err, data) {
             assert.equal(data[0].sciper, '169419');
             done();
         });
     });
 
     it('searchUserByUnitAcronym should search all members of IDEV-F*, including Kermit', function (done) {
-        fullLdapContext.users.searchUserByUnitAcronym('IDEV-F', function (err, data) {
+        this.fullLdapContext.users.searchUserByUnitAcronym('IDEV-F', function (err, data) {
             let k = data.filter(obj => {
                 return obj.displayName === 'Kermit La Grenouille';
             })
@@ -87,35 +87,35 @@ describe('User::search', function () {
 describe('Users::get', function () {
 
     it('getUsersBySciper should get Kermit La Grenouille', function (done) {
-        fullLdapContext.users.getUsersBySciper(133134, function (err, data) {
+        this.fullLdapContext.users.getUsersBySciper(133134, function (err, data) {
             assert.equal(data[0].displayName, 'Kermit La Grenouille');
             done();
         });
     });
 
     it('getUsersByName should get Kermit La Grenouille', function (done) {
-        fullLdapContext.users.getUsersByName('Kermit La Grenouille', function (err, data) {
+        this.fullLdapContext.users.getUsersByName('Kermit La Grenouille', function (err, data) {
             assert.equal(data[0].displayName, 'Kermit La Grenouille');
             done();
         });
     });
 
     it('getUsersByPhone should get 169419', function (done) {
-        fullLdapContext.users.getUsersByPhone('35455', function (err, data) {
+        this.fullLdapContext.users.getUsersByPhone('35455', function (err, data) {
             assert.equal(data[0].sciper, '169419');
             done();
         });
     });
 
     it('getUsersByMail should find 169419', function (done) {
-        fullLdapContext.users.getUsersByMail('nicolas.borboen@epfl.ch', function (err, data) {
+        this.fullLdapContext.users.getUsersByMail('nicolas.borboen@epfl.ch', function (err, data) {
             assert.equal(data[0].sciper, '169419');
             done();
         });
     });
 
     it('getUsersByUnitAcronym should search all members of IDEV-FSD, including Kermit', function (done) {
-        fullLdapContext.users.getUsersByUnitAcronym('IDEV-FSD', function (err, data) {
+        this.fullLdapContext.users.getUsersByUnitAcronym('IDEV-FSD', function (err, data) {
             let k = data.filter(obj => {
                 return obj.displayName === 'Kermit La Grenouille';
             })


### PR DESCRIPTION
Close #3

* Get rid of cache callbacks
* Use the same context for all the tests